### PR TITLE
Fix development server issues and improve cleanup

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    port: 3001,
+    host: '0.0.0.0',
     proxy: {
       '/api': {
         target: 'http://localhost:8080',

--- a/run-react-dev.sh
+++ b/run-react-dev.sh
@@ -18,11 +18,11 @@ if ! python -c "import flask" 2>/dev/null; then
 fi
 
 echo "🚀 Starting Flask backend server (port 8080)..."
-cd web_gui && python app.py &
+(cd web_gui && python app.py) &
 FLASK_PID=$!
 
 echo "⚡ Starting React development server (port 3000)..."
-cd ../frontend && npm run dev &
+(cd frontend && npm run dev) &
 REACT_PID=$!
 
 echo ""
@@ -38,8 +38,27 @@ echo ""
 cleanup() {
     echo ""
     echo "🛑 Stopping servers..."
-    kill $FLASK_PID 2>/dev/null
-    kill $REACT_PID 2>/dev/null
+    
+    # Kill Flask server
+    if [ ! -z "$FLASK_PID" ]; then
+        kill $FLASK_PID 2>/dev/null
+        sleep 1
+        kill -9 $FLASK_PID 2>/dev/null
+    fi
+    
+    # Kill React server
+    if [ ! -z "$REACT_PID" ]; then
+        kill $REACT_PID 2>/dev/null
+        sleep 1
+        kill -9 $REACT_PID 2>/dev/null
+    fi
+    
+    # Also kill any remaining processes by name
+    pkill -f "python.*app.py" 2>/dev/null
+    pkill -f "npm.*dev" 2>/dev/null
+    pkill -f "vite" 2>/dev/null
+    
+    echo "✅ Servers stopped"
     exit
 }
 


### PR DESCRIPTION
- Remove unused React import from main.tsx to fix TypeScript error
- Update Vite config to bind to all interfaces (host: '0.0.0.0') on port 3001
- Improve run-react-dev.sh cleanup function with robust process termination
- Add graceful kill followed by force kill (-9) for stubborn processes
- Add fallback process cleanup by name using pkill

Fixes issues with:
- TypeScript compilation errors preventing dev server startup
- Incomplete server shutdown leaving WebSocket connections active
- PING/PONG messages continuing after Ctrl+C

🤖 Generated with [Claude Code](https://claude.ai/code)