### PR TITLE
Fix modal header to stay visible when scrolling

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -649,6 +649,10 @@ kbd {
     align-items: center;
     padding: var(--spacing-lg);
     border-bottom: 1px solid var(--gray-200);
+    position: sticky;
+    top: 0;
+    background: var(--bg-primary);
+    z-index: 1;
 }
 
 .modal-header h3 {


### PR DESCRIPTION
- Make modal header sticky to prevent it from scrolling out of view
- Add solid background and z-index to ensure header stays above content
- Improves UX for conversation picker and other modal dialogs

🤖 Generated with [Claude Code](https://claude.ai/code)