### PR TITLE
Add production build script and fix Flask static file serving

### DIFF
--- a/run-production.sh
+++ b/run-production.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Run Spanish Tutor in Production Mode
+
+echo "🏭 Starting Spanish Tutor Production Environment..."
+echo ""
+
+# Check if we're in the right directory
+if [ ! -d "frontend" ]; then
+    echo "❌ Error: frontend directory not found"
+    echo "Please run this script from the project root directory"
+    exit 1
+fi
+
+# Check if requirements are installed
+if ! python -c "import flask" 2>/dev/null; then
+    echo "📦 Installing web requirements..."
+    pip install -r requirements-web.txt
+fi
+
+echo "🔨 Building React production build..."
+(cd frontend && npm run build)
+
+if [ $? -ne 0 ]; then
+    echo "❌ React build failed"
+    exit 1
+fi
+
+echo "✅ React build completed"
+echo ""
+
+echo "🚀 Starting Flask production server (port 8080)..."
+echo ""
+echo "🌐 Application will be available at:"
+echo "   Production Server: http://localhost:8080"
+echo ""
+echo "💡 This serves both the React app and API endpoints"
+echo "🛑 Press Ctrl+C to stop the server"
+echo ""
+
+# Function to cleanup on exit
+cleanup() {
+    echo ""
+    echo "🛑 Stopping production server..."
+    echo "✅ Server stopped"
+    exit
+}
+
+# Set trap to cleanup on script exit
+trap cleanup SIGINT SIGTERM
+
+# Start Flask server
+cd web_gui && python app.py

--- a/web_gui/app.py
+++ b/web_gui/app.py
@@ -122,7 +122,7 @@ def index():
     """Serve the React SPA for all frontend routes."""
     try:
         # Try to serve the React build first
-        return send_from_directory(os.path.join(app.static_folder, 'public'), 'index.html')
+        return send_from_directory(app.static_folder, 'index.html')
     except:
         # Fallback to development message if React build doesn't exist
         return '''
@@ -134,7 +134,7 @@ def index():
             <pre>cd frontend && npm run build</pre>
             <p>Or for development:</p>
             <pre>cd frontend && npm run dev</pre>
-            <p>The development server will be available at <a href="http://localhost:3000">http://localhost:3000</a></p>
+            <p>The development server will be available at <a href="http://localhost:3001">http://localhost:3001</a></p>
         </body>
         </html>
         '''


### PR DESCRIPTION
- Create run-production.sh script to build and serve React app in production mode
- Fix Flask route to serve React build from correct path (static/dist/index.html)
- Update fallback page to reference correct development port (3001)
- Enable single-server production deployment at localhost:8080

🤖 Generated with [Claude Code](https://claude.ai/code)