### PR TITLE
Fix conversation persistence across page navigation and refreshes

### DIFF
--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -1,116 +1,12 @@
-import React, { useEffect, useRef } from 'react';
-import { useSocket } from '@/hooks/useSocket';
+import React from 'react';
 import { useAppContext } from '@/context/AppContext';
 import ChatHeader from './ChatHeader';
 import MessageList from './MessageList';
 import ChatInput from './ChatInput';
 import WelcomeMessage from './WelcomeMessage';
-import { showToast } from '@/utils';
 
 const ChatInterface: React.FC = () => {
-  const { on } = useSocket();
-  const { chatState, addMessage, setTyping, loadMessages, clearMessages } = useAppContext();
-  const hasInitialized = useRef(false);
-
-  useEffect(() => {
-    if (hasInitialized.current) return;
-    hasInitialized.current = true;
-
-    // Set up socket event listeners
-    const cleanupFunctions: (() => void)[] = [];
-
-    // User message confirmation
-    cleanupFunctions.push(
-      on('user_message', (_data) => {
-        console.log('Message sent successfully');
-      })
-    );
-
-    // Bot response
-    cleanupFunctions.push(
-      on('bot_message', (data) => {
-        console.log('Received bot_message:', data);
-        addMessage({
-          type: 'bot',
-          message: data.message,
-          timestamp: data.timestamp,
-        });
-        setTyping(false);
-      })
-    );
-
-    // System messages
-    cleanupFunctions.push(
-      on('system_message', (data) => {
-        addMessage({
-          type: 'system',
-          message: data.message,
-          timestamp: data.timestamp,
-        });
-      })
-    );
-
-    // Conversation cleared
-    cleanupFunctions.push(
-      on('conversation_cleared', (data) => {
-        console.log('🧹 Received conversation_cleared event');
-        console.log('📊 Current messages count before clear:', chatState.messages.length);
-        clearMessages();
-        console.log('✅ Messages cleared - showing welcome message');
-        showToast('New conversation started', 'success');
-      })
-    );
-
-    // Conversation loaded
-    cleanupFunctions.push(
-      on('conversation_loaded', (data) => {
-        console.log('🔄 Received conversation_loaded:', data);
-        console.log('📨 Current state messages count before clear:', chatState.messages.length);
-        console.log('📨 Raw messages from server:', data.messages);
-        
-        const messages = data.messages
-          .filter(msg => msg.message && msg.message.trim()) // Filter out empty messages
-          .map((msg, index) => ({
-            id: `loaded-${index}`,
-            type: msg.type as 'user' | 'bot' | 'system',
-            message: msg.message,
-            timestamp: msg.timestamp,
-          }));
-        
-        console.log('✅ Processed messages for loading:', messages.length, 'messages');
-        console.log('✅ First few processed messages:', messages.slice(0, 3));
-        
-        // Clear existing messages first
-        console.log('🧹 Clearing existing messages...');
-        clearMessages();
-        
-        // Load new messages immediately (remove setTimeout delay)
-        console.log('📥 Loading new messages...');
-        loadMessages(messages);
-        
-        console.log('📊 State should now have', messages.length, 'messages');
-        showToast(`Loaded conversation with ${data.count} exchanges`, 'success');
-      })
-    );
-
-    // Error handling
-    cleanupFunctions.push(
-      on('error', (data) => {
-        console.error('Socket error:', data.message);
-        showToast(data.message, 'error');
-        setTyping(false);
-      })
-    );
-
-    // Cleanup function
-    return () => {
-      cleanupFunctions.forEach(cleanup => cleanup());
-    };
-  }, [on, addMessage, setTyping, loadMessages, clearMessages]);
-
-  // Debug logging for chat state
-  console.log('ChatInterface render - messages count:', chatState.messages.length);
-  console.log('ChatInterface render - messages:', chatState.messages);
+  const { chatState } = useAppContext();
 
   return (
     <div className="chat-container">

--- a/frontend/src/context/AppContext.tsx
+++ b/frontend/src/context/AppContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useReducer, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, ReactNode, useRef } from 'react';
 import type { ChatState, AppSettings, Message } from '@/types';
-import { generateId } from '@/utils';
+import { generateId, showToast } from '@/utils';
+import { socketService } from '@/services/socket';
 
 // Initial state
 const initialChatState: ChatState = {
@@ -170,6 +171,116 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const updateSettings = (newSettings: Partial<AppSettings>) => {
     settingsDispatch({ type: 'UPDATE_SETTINGS', payload: newSettings });
   };
+
+  // Socket event listeners setup - moved here so they persist across page navigation
+  const socketInitialized = useRef(false);
+  
+  useEffect(() => {
+    if (socketInitialized.current) return;
+    socketInitialized.current = true;
+    
+    console.log('🔗 Setting up socket listeners in AppProvider (persistent across navigation)');
+    
+    // Connect to socket
+    const socket = socketService.connect();
+    
+    // Connection status
+    const handleConnectionStatus = (data: any) => {
+      setConnectionStatus(data.connected);
+    };
+    
+    // User message confirmation
+    const handleUserMessage = (_data: any) => {
+      console.log('Message sent successfully');
+    };
+    
+    // Bot response
+    const handleBotMessage = (data: any) => {
+      console.log('Received bot_message:', data);
+      addMessage({
+        type: 'bot',
+        message: data.message,
+        timestamp: data.timestamp,
+      });
+      setTyping(false);
+    };
+    
+    // System messages
+    const handleSystemMessage = (data: any) => {
+      addMessage({
+        type: 'system',
+        message: data.message,
+        timestamp: data.timestamp,
+      });
+    };
+    
+    // Conversation cleared
+    const handleConversationCleared = (data: any) => {
+      console.log('🧹 Received conversation_cleared event (AppProvider)');
+      console.log('📊 Current messages count before clear:', chatState.messages.length);
+      clearMessages();
+      console.log('✅ Messages cleared - showing welcome message (AppProvider)');
+      showToast('New conversation started', 'success');
+    };
+    
+    // Conversation loaded
+    const handleConversationLoaded = (data: any) => {
+      console.log('🔄 Received conversation_loaded (AppProvider):', data);
+      console.log('📨 Current state messages count before clear:', chatState.messages.length);
+      console.log('📨 Raw messages from server:', data.messages);
+      
+      const messages = data.messages
+        .filter((msg: any) => msg.message && msg.message.trim()) // Filter out empty messages
+        .map((msg: any, index: number) => ({
+          id: `loaded-${index}`,
+          type: msg.type as 'user' | 'bot' | 'system',
+          message: msg.message,
+          timestamp: msg.timestamp,
+        }));
+      
+      console.log('✅ Processed messages for loading:', messages.length, 'messages');
+      console.log('✅ First few processed messages:', messages.slice(0, 3));
+      
+      // Clear existing messages first
+      console.log('🧹 Clearing existing messages...');
+      clearMessages();
+      
+      // Load new messages
+      console.log('📥 Loading new messages...');
+      loadMessages(messages);
+      
+      console.log('📊 State should now have', messages.length, 'messages');
+      showToast(`Loaded conversation with ${data.count} exchanges`, 'success');
+    };
+    
+    // Error handling
+    const handleError = (data: any) => {
+      console.error('Socket error:', data.message);
+      showToast(data.message, 'error');
+      setTyping(false);
+    };
+    
+    // Register event listeners
+    socketService.on('connection_status', handleConnectionStatus);
+    socketService.on('user_message', handleUserMessage);
+    socketService.on('bot_message', handleBotMessage);
+    socketService.on('system_message', handleSystemMessage);
+    socketService.on('conversation_cleared', handleConversationCleared);
+    socketService.on('conversation_loaded', handleConversationLoaded);
+    socketService.on('error', handleError);
+    
+    // Cleanup on unmount
+    return () => {
+      console.log('🧹 Cleaning up socket listeners (AppProvider unmount)');
+      socketService.off('connection_status', handleConnectionStatus);
+      socketService.off('user_message', handleUserMessage);
+      socketService.off('bot_message', handleBotMessage);
+      socketService.off('system_message', handleSystemMessage);
+      socketService.off('conversation_cleared', handleConversationCleared);
+      socketService.off('conversation_loaded', handleConversationLoaded);
+      socketService.off('error', handleError);
+    };
+  }, []); // Empty dependency array so this only runs once
 
   const contextValue: AppContextType = {
     chatState,

--- a/frontend/src/pages/GrammarNotesPage.tsx
+++ b/frontend/src/pages/GrammarNotesPage.tsx
@@ -42,11 +42,28 @@ const GrammarNotesPage: React.FC = () => {
     }
   };
 
-  const handleRefresh = () => {
-    setLoading(true);
-    setError(null);
-    // Reload the component
-    window.location.reload();
+  const handleRefresh = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      console.log('🔄 Refreshing grammar notes data (not reloading page)');
+      
+      const response = await apiService.getGrammarNotes();
+      
+      if (response.error) {
+        setError(response.error);
+        showToast(response.error, 'error');
+      } else if (response.data) {
+        setNotes(response.data);
+        showToast('Grammar notes refreshed', 'success');
+      }
+    } catch (err) {
+      console.error('Failed to refresh grammar notes:', err);
+      setError('Failed to refresh grammar notes');
+      showToast('Failed to refresh grammar notes', 'error');
+    } finally {
+      setLoading(false);
+    }
   };
 
   if (loading) {


### PR DESCRIPTION
- Move socket event listeners from ChatInterface to AppProvider level
- Ensures conversation state persists when navigating between pages
- Fix Grammar Notes refresh to not reload entire page
- Replace window.location.reload() with proper data refresh
- Conversation now persists across Chat ↔ Grammar Notes navigation
- Add proper loading states and success messages for refresh

🤖 Generated with [Claude Code](https://claude.ai/code)